### PR TITLE
Add non-blocking read option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ embedded-hal = "0.2"
 bitflags = "1.2"
 crc_all = "0.2"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
+nb = "1.0"
 
 [dev_dependencies]
 linux-embedded-hal = "0.3"

--- a/examples/aht20_nonblocking.rs
+++ b/examples/aht20_nonblocking.rs
@@ -1,0 +1,43 @@
+//! Linux I2C Demo
+
+use {
+    aht20::*,
+    embedded_hal::blocking::delay::DelayMs,
+    linux_embedded_hal as hal,
+    std::{env, process},
+};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        println!("usage: {} /dev/i2c-N", args[0]);
+        process::exit(1);
+    }
+
+    let i2c = hal::I2cdev::new(&args[1]).unwrap();
+
+    let mut dev = Aht20::new(i2c, hal::Delay).unwrap();
+
+    loop {
+        print!("Reading...");
+        dev.nonblocking_start().unwrap();
+        let (h, t) = loop {
+            match dev.nonblocking_get_result() {
+                Ok((h , t)) => break (h, t),
+                Err(nb::Error::WouldBlock) => (),
+                Err(nb::Error::Other(e)) => e.unwrap(),
+            }
+            print(".");
+            hal::Delay::delay_ms(10);
+        };
+        println!("");
+
+        println!(
+            "relative humidity={0}%; temperature={1}C",
+            h.rh(),
+            t.celsius()
+        );
+
+        hal::Delay.delay_ms(1000u16);
+    }
+}


### PR DESCRIPTION
For some microcontroller applications, blocking for tens of milliseconds can be a big problem. For example, in my use case I need to poll the USB connection at least once every 10ms to maintain the connection, and threads aren't an option.

This PR adds a pair of methods to read sensor values in a nonblocking way. If the result is not ready yet, instead of delaying, the function returns a `nb::Error::WouldBlock`. The caller can then choose how to handle the needed delay.